### PR TITLE
NO-TICKET: get linting-rules into the common-tools repo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "./node_modules/alcumus-linting-rules/resources/linting/eslint/default.js"
+        "./src/linting/resources/eslint/default.js"
     ],
     "root": true
 }

--- a/editorconfig-cli.js
+++ b/editorconfig-cli.js
@@ -6,7 +6,7 @@ const path = require('path');
 fs.symlink = promisify(fs.symlink);
 fs.rename = promisify(fs.rename);
 
-const source = path.relative(process.cwd(), path.join(__dirname, 'node_modules/alcumus-linting-rules/resources/.editorconfig'));
+const source = path.relative(process.cwd(), path.join(__dirname, './src/linting/resources/.editorconfig'));
 const target = path.join(process.cwd(), '.editorconfig');
 const tempLocation = path.join(__dirname, 'temp-symlink-file');
 

--- a/linting-cli.js
+++ b/linting-cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const _ = require('lodash');
-const lintingRules = require('alcumus-linting-rules');
+const lintingRules = require('./src/linting/linting-rules.js');
 
 const checkLinterAlias = (linter, alias, args, matchedLinters) => {
     if (args.includes(alias)) {
@@ -35,7 +35,7 @@ const args = process.argv.slice(2).map(argument => argument.toLowerCase());
 const linters = getLinters(args);
 const types = args.filter(argument => !linters.includes(argument));
 
-require('./src/linting.js')
+require('./src/linting/linting.js')
     .addLinters(linters, process.cwd(), types)
     // eslint-disable-next-line no-console
     .catch(error => console.error(error));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@alcumus/linting-rules": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@alcumus/linting-rules/-/linting-rules-0.0.6.tgz",
-      "integrity": "sha512-2Bv42a2gsradQHV0KvrIzoHc0219rJy/Kd6lgEq1w2Cm5i5qZ9MBACTaqy2PUcpJp6iFx4NZFlTmK9kMkXCctA=="
-    },
     "@angular/compiler": {
       "version": "6.1.10",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@alcumus/linting-rules": "0.0.6",
     "@angular/compiler": "^6.1.10",
     "@angular/core": "^6.1.10",
     "angular-tslint-rules": "^1.5.0",

--- a/src/linting/linting-rules.js
+++ b/src/linting/linting-rules.js
@@ -1,0 +1,39 @@
+const promisify = require('util').promisify;
+const path = require('path');
+const fs = require('fs');
+fs.readdir = promisify(fs.readdir);
+
+module.exports = {
+    dependencies: {
+        react: {
+            'eslint-plugin-react': 'latest',
+            'eslint-plugin-react-hooks': 'latest'
+        }
+    },
+    linters: [{
+        name: 'eslint',
+        configFile: '.eslintrc.json',
+        fileMatcher: '"src/**/*.js" "test/**/*.js" "*.js"'
+    }, {
+        name: 'tslint',
+        configFile: 'tslint.json',
+        fileMatcher: '--project ./tsconfig.json "src/**/*.ts" "*.ts"'
+    }, {
+        name: 'stylelint',
+        configFile: '.stylelintrc.json',
+        fileMatcher: '"src/**/*.scss" "*.scss"'
+    }],
+    getRules: (linter) => {
+        linter = linter.name || linter;
+        const linterDirectory = `${__dirname}/${linter}`;
+        const relativePath = path.relative(process.cwd(), linterDirectory);
+        return fs.readdir(linterDirectory)
+            .then(files => files
+                .filter(file => file.match(/\.js$/))
+                .map(file => ({
+                    path: `./${relativePath}/${file}`,
+                    name: file.replace(/\.js/, '')
+                }))
+            );
+    }
+};

--- a/src/linting/linting.js
+++ b/src/linting/linting.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 
-const lintingRules = require('alcumus-linting-rules');
+const lintingRules = require('.src/linting/linting-rules.js');
 
 fs.writeFile = promisify(fs.writeFile);
 

--- a/src/linting/linting.js
+++ b/src/linting/linting.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 
-const lintingRules = require('.src/linting/linting-rules.js');
+const lintingRules = require('./src/linting/linting-rules.js');
 
 fs.writeFile = promisify(fs.writeFile);
 

--- a/src/linting/resources/.editorconfig
+++ b/src/linting/resources/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[package*.json]
+indent_size = 2

--- a/src/linting/resources/eslint/browser.js
+++ b/src/linting/resources/eslint/browser.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+    extends: ['./default.js'],
+    env: {
+        es6: true,
+        browser: true
+    },
+    parserOptions: {
+        sourceType: 'script'
+    }
+};

--- a/src/linting/resources/eslint/default.js
+++ b/src/linting/resources/eslint/default.js
@@ -1,0 +1,19 @@
+
+module.exports = {
+    extends: ['eslint:recommended'],
+    env: {
+        es6: true,
+        node: true
+    },
+    rules: {
+        'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
+        indent: ['error', 4],
+        quotes: ['error', 'single', { avoidEscape: true }],
+        semi: ['error', 'always'],
+        'no-unused-vars': ['error', { argsIgnorePattern: '^__', varsIgnorePattern: '^__' }]
+    },
+    parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 2018
+    }
+};

--- a/src/linting/resources/eslint/react.js
+++ b/src/linting/resources/eslint/react.js
@@ -1,0 +1,24 @@
+module.exports = {
+    extends: [
+        './browser.js',
+        'plugin:react/recommended'
+    ],
+    env: {
+        jest: true
+    },
+    rules: {
+        'react-hooks/rules-of-hooks': 'error',
+        'jsx-quotes': ['error', 'prefer-double']
+    },
+    plugins: [
+        'react-hooks'
+    ],
+    parserOptions: {
+        sourceType: 'module'
+    },
+    settings: {
+        react: {
+            version: 'latest'
+        }
+    }
+};

--- a/src/linting/resources/stylelint/default.js
+++ b/src/linting/resources/stylelint/default.js
@@ -1,0 +1,10 @@
+module.exports = {
+    extends: ['stylelint-config-standard'],
+    plugins: [
+        'stylelint-scss'
+    ],
+    rules: {
+        indentation: 4,
+        'scss/selector-no-redundant-nesting-selector': true
+    }
+};

--- a/src/linting/resources/tslint/angular.js
+++ b/src/linting/resources/tslint/angular.js
@@ -1,0 +1,15 @@
+
+module.exports = {
+    extends: ['angular-tslint-rules', './default.js'],
+    rules: {
+        'angular-whitespace': [true, 'check-interpolation', 'check-pipe'],
+        'component-selector': false,
+        'directive-selector': false,
+        i18n: false,
+        'no-template-call-expression': false,
+        "trackBy-function": false
+    },
+    rulesDirectory: [
+        '../../../node_modules/codelyzer'
+    ]
+};

--- a/src/linting/resources/tslint/default.js
+++ b/src/linting/resources/tslint/default.js
@@ -1,0 +1,36 @@
+
+module.exports = {
+    extends: ['tslint:recommended'],
+    rules: {
+        'array-type': [true, 'array'],
+        'comment-format': [true, 'check-space'],
+        indent: [true, 'spaces', 4],
+        'interface-name': false,
+        'newline-per-chained-call': false,
+        'no-console': [
+            true,
+            'log',
+            'debug',
+            'info',
+            'time',
+            'timeEnd',
+            'trace'
+        ],
+        'no-null-keyword': false,
+        'no-unused-variable': true,
+        'object-literal-sort-keys': false,
+        'prefer-conditional-expression': false,
+        quotemark: [true, 'single', 'jsx-double', 'avoid-escape'],
+        'trailing-comma': [
+            true,
+            {
+                multiline: 'never',
+                singleline: 'never'
+            }
+        ],
+        'variable-name': [true, 'ban-keywords', 'check-format']
+    },
+    rulesDirectory: [
+        '../../../node_modules/tslint-eslint-rules/dist/rules'
+    ]
+};


### PR DESCRIPTION
The **new** files are just copies of what is currently in `@alcumus/linting-rules`. Some paths have had to change to reference the new/local files.